### PR TITLE
Allow wildcard for all route namespaces

### DIFF
--- a/models/Route.php
+++ b/models/Route.php
@@ -111,17 +111,13 @@ class Route extends AbstractItem
         }
 
         foreach ($allowedRoutes as $allowedRoute) {
-            // If some controller fully allowed (wildcard)
+            // If some namespace fully allowed (wildcard)
             if (substr($allowedRoute, -1) == '*') {
-                $routeArray = explode('/', $route);
-                array_splice($routeArray, -1);
+	            $allowedRouteArray = explode('/', $allowedRoute);
+	            array_splice($allowedRouteArray, -1);
 
-                $allowedRouteArray = explode('/', $allowedRoute);
-                array_splice($allowedRouteArray, -1);
-
-                if (array_diff($routeArray, $allowedRouteArray) === array()) {
-                    return true;
-                }
+            	if(strpos($route, join('/', $allowedRouteArray)) === 0)
+            		return true;
             }
         }
 


### PR DESCRIPTION
With this change we can create permissions for custom rewrite rules for example for rule:
`controller/action/<id:\d+>/<slug:\w+>`
we can now create permission:
`controller/action`

I've left `explode` and `array_slice` because I'm not sure if using `substr($allowedRoute, 0, -2)` would be backwards compatible.